### PR TITLE
Fix xtend plugin

### DIFF
--- a/eclipse/pom.xml
+++ b/eclipse/pom.xml
@@ -5,7 +5,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>tools.mdsd</groupId>
 	<artifactId>eclipse-parent</artifactId>	
-	<version>0.1.1-SNAPSHOT</version>
+	<version>0.1.1</version>
 	<name>${project.artifactId}</name>
 	<description>A common parent POM for all Eclipse builds of MDSD.tools.</description>
 	<url>http://mdsd.tools</url>

--- a/eclipse/pom.xml
+++ b/eclipse/pom.xml
@@ -292,6 +292,21 @@
 									<artifactId>org.eclipse.equinox.common</artifactId>
 									<version>[3.8.0,4.0.0)</version>
 								</dependency>
+								<dependency>
+									<groupId>org.eclipse.jdt</groupId>
+									<artifactId>org.eclipse.jdt.core</artifactId>
+									<version>3.15.0</version>
+								</dependency>
+								<dependency>
+									<groupId>org.eclipse.jdt</groupId>
+									<artifactId>org.eclipse.jdt.compiler.apt</artifactId>
+									<version>1.3.300</version>
+								</dependency>
+								<dependency>
+									<groupId>org.eclipse.jdt</groupId>
+									<artifactId>org.eclipse.jdt.compiler.tool</artifactId>
+									<version>1.2.300</version>
+								</dependency>
 							</dependencies>
 						</plugin>
 

--- a/eclipse/pom.xml
+++ b/eclipse/pom.xml
@@ -5,7 +5,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>tools.mdsd</groupId>
 	<artifactId>eclipse-parent</artifactId>	
-	<version>0.1.1</version>
+	<version>0.1.2-SNAPSHOT</version>
 	<name>${project.artifactId}</name>
 	<description>A common parent POM for all Eclipse builds of MDSD.tools.</description>
 	<url>http://mdsd.tools</url>

--- a/eclipse/product/pom.xml
+++ b/eclipse/product/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>tools.mdsd</groupId>
 		<artifactId>eclipse-parent</artifactId>
-		<version>0.1.1</version>
+		<version>0.1.2-SNAPSHOT</version>
 	</parent>
 	<artifactId>eclipse-parent-product</artifactId>
 	<name>${project.artifactId}</name>

--- a/eclipse/product/pom.xml
+++ b/eclipse/product/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>tools.mdsd</groupId>
 		<artifactId>eclipse-parent</artifactId>
-		<version>0.1.1-SNAPSHOT</version>
+		<version>0.1.1</version>
 	</parent>
 	<artifactId>eclipse-parent-product</artifactId>
 	<name>${project.artifactId}</name>

--- a/eclipse/updatesite/pom.xml
+++ b/eclipse/updatesite/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>tools.mdsd</groupId>
 		<artifactId>eclipse-parent</artifactId>
-		<version>0.1.1</version>
+		<version>0.1.2-SNAPSHOT</version>
 	</parent>
 	<artifactId>eclipse-parent-updatesite</artifactId>
 	<name>${project.artifactId}</name>

--- a/eclipse/updatesite/pom.xml
+++ b/eclipse/updatesite/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>tools.mdsd</groupId>
 		<artifactId>eclipse-parent</artifactId>
-		<version>0.1.1-SNAPSHOT</version>
+		<version>0.1.1</version>
 	</parent>
 	<artifactId>eclipse-parent-updatesite</artifactId>
 	<name>${project.artifactId}</name>


### PR DESCRIPTION
Fixes dependency issues of the xtend-maven-plugin in current version of parent POMs.

A release has already been staged.