### PR TITLE
Added support for MWE2-based code generation

### DIFF
--- a/eclipse/pom.xml
+++ b/eclipse/pom.xml
@@ -402,6 +402,83 @@
 			</build>
 		</profile>
 
+		<profile>
+			<id>execute-generate-workflow</id>
+			<activation>
+				<file>
+					<exists>workflow/generate.mwe2</exists>
+				</file>
+			</activation>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.codehaus.mojo</groupId>
+						<artifactId>exec-maven-plugin</artifactId>
+						<version>1.4.0</version>
+						<executions>
+							<execution>
+								<id>ExecuteMWE2LauncherForGenerate</id>
+								<phase>generate-sources</phase>
+								<goals>
+									<goal>java</goal>
+								</goals>
+								<configuration>
+									<mainClass>org.eclipse.emf.mwe2.launch.runtime.Mwe2Launcher</mainClass>
+									<arguments>
+										<argument>/${project.basedir}/workflow/generate.mwe2</argument>
+										<argument>-p</argument>
+										<argument>workspaceRoot=/${maven.multiModuleProjectDirectory}</argument>
+									</arguments>
+									<classpathScope>compile</classpathScope>
+									<includePluginDependencies>true</includePluginDependencies>
+									<cleanupDaemonThreads>false
+									</cleanupDaemonThreads><!-- see https://bugs.eclipse.org/bugs/show_bug.cgi?id=475098#c3 -->
+								</configuration>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+		<profile>
+			<id>execute-clean-workflow</id>
+			<activation>
+				<file>
+					<exists>workflow/clean.mwe2</exists>
+				</file>
+			</activation>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.codehaus.mojo</groupId>
+						<artifactId>exec-maven-plugin</artifactId>
+						<version>1.4.0</version>
+						<executions>
+							<execution>
+								<id>ExecuteMWE2LauncherForClean</id>
+								<phase>clean</phase>
+								<goals>
+									<goal>java</goal>
+								</goals>
+								<configuration>
+									<mainClass>org.eclipse.emf.mwe2.launch.runtime.Mwe2Launcher</mainClass>
+									<arguments>
+										<argument>/${project.basedir}/workflow/clean.mwe2</argument>
+										<argument>-p</argument>
+										<argument>workspaceRoot=/${maven.multiModuleProjectDirectory}</argument>
+									</arguments>
+									<classpathScope>compile</classpathScope>
+									<includePluginDependencies>true</includePluginDependencies>
+									<cleanupDaemonThreads>false
+									</cleanupDaemonThreads><!-- see https://bugs.eclipse.org/bugs/show_bug.cgi?id=475098#c3 -->
+								</configuration>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+
 		<!-- OS specific properties -->
 		<profile>
 			<id>win32-x86</id>


### PR DESCRIPTION
The two added profiles allow to automatically execute a MWE2-Workflow as part of the "clean" and the "generate-sources" phase of a maven build. To trigger the execution is is sufficient to provide the respective workflow as `workflow/generate.mwe2` and `workflow/clean.mwe2`. If the file is present it will be picked up during the appropriate phase.
The workflow is expected to accept a `workspaceRoot` parameter, which will be set to the root folder of the project.