### PR TITLE
Update target platform to 2019-03, hence drop 32bit support

### DIFF
--- a/eclipse/pom.xml
+++ b/eclipse/pom.xml
@@ -282,28 +282,6 @@
 									</configuration>
 								</execution>
 							</executions>
-							<dependencies>
-								<dependency>
-									<groupId>org.eclipse.platform</groupId>
-									<artifactId>org.eclipse.equinox.common</artifactId>
-									<version>[3.8.0,4.0.0)</version>
-								</dependency>
-								<dependency>
-									<groupId>org.eclipse.jdt</groupId>
-									<artifactId>org.eclipse.jdt.core</artifactId>
-									<version>3.15.0</version>
-								</dependency>
-								<dependency>
-									<groupId>org.eclipse.jdt</groupId>
-									<artifactId>org.eclipse.jdt.compiler.apt</artifactId>
-									<version>1.3.300</version>
-								</dependency>
-								<dependency>
-									<groupId>org.eclipse.jdt</groupId>
-									<artifactId>org.eclipse.jdt.compiler.tool</artifactId>
-									<version>1.2.300</version>
-								</dependency>
-							</dependencies>
 						</plugin>
 
 						<plugin>

--- a/eclipse/pom.xml
+++ b/eclipse/pom.xml
@@ -271,7 +271,7 @@
 						<plugin>
 							<groupId>org.eclipse.xtend</groupId>
 							<artifactId>xtend-maven-plugin</artifactId>
-							<version>2.14.0</version>
+							<version>2.17.1</version>
 							<executions>
 								<execution>
 									<goals>
@@ -477,20 +477,6 @@
 
 		<!-- OS specific properties -->
 		<profile>
-			<id>win32-x86</id>
-			<activation>
-				<os>
-					<arch>x86</arch>
-					<family>windows</family>
-				</os>
-			</activation>
-			<properties>
-				<target.platform.os>win32</target.platform.os>
-				<target.platform.ws>win32</target.platform.ws>
-				<target.platform.arch>x86</target.platform.arch>
-			</properties>
-		</profile>
-		<profile>
 			<id>win32-amd64</id>
 			<activation>
 				<os>
@@ -502,21 +488,6 @@
 				<target.platform.os>win32</target.platform.os>
 				<target.platform.ws>win32</target.platform.ws>
 				<target.platform.arch>x86_64</target.platform.arch>
-			</properties>
-		</profile>
-		<profile>
-			<id>linux-x86</id>
-			<activation>
-				<os>
-					<arch>i386</arch>
-					<family>unix</family>
-					<name>linux</name>
-				</os>
-			</activation>
-			<properties>
-				<target.platform.os>linux</target.platform.os>
-				<target.platform.ws>gtk</target.platform.ws>
-				<target.platform.arch>x86</target.platform.arch>
 			</properties>
 		</profile>
 		<profile>

--- a/eclipse/product/pom.xml
+++ b/eclipse/product/pom.xml
@@ -38,17 +38,7 @@
 									<environment>
 										<os>linux</os>
 										<ws>gtk</ws>
-										<arch>x86</arch>
-									</environment>
-									<environment>
-										<os>linux</os>
-										<ws>gtk</ws>
 										<arch>x86_64</arch>
-									</environment>
-									<environment>
-										<os>win32</os>
-										<ws>win32</ws>
-										<arch>x86</arch>
 									</environment>
 									<environment>
 										<os>win32</os>

--- a/eclipse/updatesite/pom.xml
+++ b/eclipse/updatesite/pom.xml
@@ -24,7 +24,7 @@
 				</file>
 			</activation>
 			<properties>
-				<org.palladiosimulator.maven.tychotprefresh.tplocation.0>tools.mdsd:eclipse-target-platforms:0.1.2:eclipse-modeling-photon-0:target</org.palladiosimulator.maven.tychotprefresh.tplocation.0>
+				<org.palladiosimulator.maven.tychotprefresh.tplocation.0>tools.mdsd:eclipse-target-platforms:0.1.2:eclipse-modeling-2019-03:target</org.palladiosimulator.maven.tychotprefresh.tplocation.0>
 				<org.palladiosimulator.maven.tychotprefresh.tpproject.groupId>tools.mdsd</org.palladiosimulator.maven.tychotprefresh.tpproject.groupId>
 				<org.palladiosimulator.maven.tychotprefresh.tpproject.artifactId>target-platform-merged-temporary</org.palladiosimulator.maven.tychotprefresh.tpproject.artifactId>
 				<org.palladiosimulator.maven.tychotprefresh.tpproject.version>1.0.0</org.palladiosimulator.maven.tychotprefresh.tpproject.version>
@@ -51,17 +51,7 @@
 									<environment>
 										<os>linux</os>
 										<ws>gtk</ws>
-										<arch>x86</arch>
-									</environment>
-									<environment>
-										<os>linux</os>
-										<ws>gtk</ws>
 										<arch>x86_64</arch>
-									</environment>
-									<environment>
-										<os>win32</os>
-										<ws>win32</ws>
-										<arch>x86</arch>
 									</environment>
 									<environment>
 										<os>win32</os>


### PR DESCRIPTION
In order to properly support building with Java 11 we need to increase the Xtext / Xtend version to 2.17 which is part of Eclipse 2019-03. Since Eclipse dropped support for x86-32bit in 2018-12 we need to remove the respective targets. I don't think anybody will mind.