### PR TITLE
Release 0.3.2

### DIFF
--- a/eclipse/pom.xml
+++ b/eclipse/pom.xml
@@ -5,7 +5,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>tools.mdsd</groupId>
 	<artifactId>eclipse-parent</artifactId>	
-	<version>0.3.2-SNAPSHOT</version>
+	<version>0.3.2</version>
 	<name>${project.artifactId}</name>
 	<description>A common parent POM for all Eclipse builds of MDSD.tools.</description>
 	<url>http://mdsd.tools</url>

--- a/eclipse/pom.xml
+++ b/eclipse/pom.xml
@@ -5,7 +5,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>tools.mdsd</groupId>
 	<artifactId>eclipse-parent</artifactId>	
-	<version>0.3.2</version>
+	<version>0.3.3-SNAPSHOT</version>
 	<name>${project.artifactId}</name>
 	<description>A common parent POM for all Eclipse builds of MDSD.tools.</description>
 	<url>http://mdsd.tools</url>

--- a/eclipse/product/pom.xml
+++ b/eclipse/product/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>tools.mdsd</groupId>
 		<artifactId>eclipse-parent</artifactId>
-		<version>0.3.2</version>
+		<version>0.3.3-SNAPSHOT</version>
 	</parent>
 	<artifactId>eclipse-parent-product</artifactId>
 	<name>${project.artifactId}</name>

--- a/eclipse/product/pom.xml
+++ b/eclipse/product/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>tools.mdsd</groupId>
 		<artifactId>eclipse-parent</artifactId>
-		<version>0.3.2-SNAPSHOT</version>
+		<version>0.3.2</version>
 	</parent>
 	<artifactId>eclipse-parent-product</artifactId>
 	<name>${project.artifactId}</name>

--- a/eclipse/updatesite/pom.xml
+++ b/eclipse/updatesite/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>tools.mdsd</groupId>
 		<artifactId>eclipse-parent</artifactId>
-		<version>0.3.2-SNAPSHOT</version>
+		<version>0.3.2</version>
 	</parent>
 	<artifactId>eclipse-parent-updatesite</artifactId>
 	<name>${project.artifactId}</name>

--- a/eclipse/updatesite/pom.xml
+++ b/eclipse/updatesite/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>tools.mdsd</groupId>
 		<artifactId>eclipse-parent</artifactId>
-		<version>0.3.2</version>
+		<version>0.3.3-SNAPSHOT</version>
 	</parent>
 	<artifactId>eclipse-parent-updatesite</artifactId>
 	<name>${project.artifactId}</name>


### PR DESCRIPTION
The release is necessary because other parent POMs using these as base reuse the gpg signing definition that has been fixed recently.

A release has already been staged at Sonatype.