### PR TITLE
Support 2019-09

### DIFF
--- a/eclipse/pom.xml
+++ b/eclipse/pom.xml
@@ -5,7 +5,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>tools.mdsd</groupId>
 	<artifactId>eclipse-parent</artifactId>	
-	<version>0.4.0</version>
+	<version>0.4.1-SNAPSHOT</version>
 	<name>${project.artifactId}</name>
 	<description>A common parent POM for all Eclipse builds of MDSD.tools.</description>
 	<url>http://mdsd.tools</url>

--- a/eclipse/pom.xml
+++ b/eclipse/pom.xml
@@ -5,7 +5,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>tools.mdsd</groupId>
 	<artifactId>eclipse-parent</artifactId>	
-	<version>0.4.0-SNAPSHOT</version>
+	<version>0.4.0</version>
 	<name>${project.artifactId}</name>
 	<description>A common parent POM for all Eclipse builds of MDSD.tools.</description>
 	<url>http://mdsd.tools</url>

--- a/eclipse/pom.xml
+++ b/eclipse/pom.xml
@@ -5,7 +5,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>tools.mdsd</groupId>
 	<artifactId>eclipse-parent</artifactId>	
-	<version>0.3.3-SNAPSHOT</version>
+	<version>0.4.0-SNAPSHOT</version>
 	<name>${project.artifactId}</name>
 	<description>A common parent POM for all Eclipse builds of MDSD.tools.</description>
 	<url>http://mdsd.tools</url>
@@ -47,7 +47,7 @@
 			-tag 'nooverride:a:Restriction:'
 			-tag 'category:a:Category:'
 			-link ${java.api.doc}
-			-link http://help.eclipse.org/2019-06/topic/org.eclipse.platform.doc.isv/reference/api
+			-link http://help.eclipse.org/2019-09/topic/org.eclipse.platform.doc.isv/reference/api
 			-link https://download.eclipse.org/modeling/emf/emf/javadoc/2.11/
 			-link https://download.eclipse.org/modeling/emft/mwe/javadoc/2.9/
 		</javadoc.args>

--- a/eclipse/product/pom.xml
+++ b/eclipse/product/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>tools.mdsd</groupId>
 		<artifactId>eclipse-parent</artifactId>
-		<version>0.4.0-SNAPSHOT</version>
+		<version>0.4.0</version>
 	</parent>
 	<artifactId>eclipse-parent-product</artifactId>
 	<name>${project.artifactId}</name>

--- a/eclipse/product/pom.xml
+++ b/eclipse/product/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>tools.mdsd</groupId>
 		<artifactId>eclipse-parent</artifactId>
-		<version>0.4.0</version>
+		<version>0.4.1-SNAPSHOT</version>
 	</parent>
 	<artifactId>eclipse-parent-product</artifactId>
 	<name>${project.artifactId}</name>

--- a/eclipse/product/pom.xml
+++ b/eclipse/product/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>tools.mdsd</groupId>
 		<artifactId>eclipse-parent</artifactId>
-		<version>0.3.3-SNAPSHOT</version>
+		<version>0.4.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>eclipse-parent-product</artifactId>
 	<name>${project.artifactId}</name>

--- a/eclipse/updatesite/pom.xml
+++ b/eclipse/updatesite/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>tools.mdsd</groupId>
 		<artifactId>eclipse-parent</artifactId>
-		<version>0.3.3-SNAPSHOT</version>
+		<version>0.4.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>eclipse-parent-updatesite</artifactId>
 	<name>${project.artifactId}</name>
@@ -24,7 +24,7 @@
 				</file>
 			</activation>
 			<properties>
-				<org.palladiosimulator.maven.tychotprefresh.tplocation.0>tools.mdsd:eclipse-target-platforms:0.1.4:eclipse-modeling-2019-06:target</org.palladiosimulator.maven.tychotprefresh.tplocation.0>
+				<org.palladiosimulator.maven.tychotprefresh.tplocation.0>tools.mdsd:eclipse-target-platforms:0.1.5:eclipse-modeling-2019-09:target</org.palladiosimulator.maven.tychotprefresh.tplocation.0>
 				<org.palladiosimulator.maven.tychotprefresh.tpproject.groupId>tools.mdsd</org.palladiosimulator.maven.tychotprefresh.tpproject.groupId>
 				<org.palladiosimulator.maven.tychotprefresh.tpproject.artifactId>target-platform-merged-temporary</org.palladiosimulator.maven.tychotprefresh.tpproject.artifactId>
 				<org.palladiosimulator.maven.tychotprefresh.tpproject.version>1.0.0</org.palladiosimulator.maven.tychotprefresh.tpproject.version>

--- a/eclipse/updatesite/pom.xml
+++ b/eclipse/updatesite/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>tools.mdsd</groupId>
 		<artifactId>eclipse-parent</artifactId>
-		<version>0.4.0</version>
+		<version>0.4.1-SNAPSHOT</version>
 	</parent>
 	<artifactId>eclipse-parent-updatesite</artifactId>
 	<name>${project.artifactId}</name>

--- a/eclipse/updatesite/pom.xml
+++ b/eclipse/updatesite/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>tools.mdsd</groupId>
 		<artifactId>eclipse-parent</artifactId>
-		<version>0.4.0-SNAPSHOT</version>
+		<version>0.4.0</version>
 	</parent>
 	<artifactId>eclipse-parent-updatesite</artifactId>
 	<name>${project.artifactId}</name>


### PR DESCRIPTION
I replaced 2019-06 with 2019-09 and increased the version to 0.4.0 as this is a new supported Eclipse version.

A release has already been staged at Sonatype.

This PR can be accepted after MDSD-Tools/Maven-Build-TargetPlatforms#18.