### PR TITLE
Custom configuration of clean plugin to not delete .gitkeep

### DIFF
--- a/eclipse/pom.xml
+++ b/eclipse/pom.xml
@@ -313,22 +313,22 @@
 							<groupId>org.apache.maven.plugins</groupId>
 							<artifactId>maven-clean-plugin</artifactId>
 							<version>3.1.0</version>
-							<executions>
-								<execution>
-									<id>gen-clean</id>
-									<phase>clean</phase>
-									<goals>
-										<goal>clean</goal>
-									</goals>
-									<configuration>
-										<filesets>
-											<fileset>
-												<directory>xtend-gen</directory>
-											</fileset>
-										</filesets>
-									</configuration>
-								</execution>
-							</executions>
+							<configuration>
+								<excludeDefaultDirectories>true</excludeDefaultDirectories>
+								<filesets>
+									<fileset>
+										<directory>${project.basedir}</directory>
+										<includes>
+											<include>target/**</include>
+											<include>xtend-gen/**</include>
+											<include>emfparsley-gen/**</include>
+										</includes>
+										<excludes>
+											<exclude>*/.gitkeep</exclude>
+										</excludes>
+									</fileset>
+								</filesets>
+							</configuration>
 						</plugin>
 
 						<plugin>


### PR DESCRIPTION
This PR customized the clean step even more to not delete `.gitkeep` files in source generation folders. It also consider files generated by EMF Parsley during the cleaning step.