### PR TITLE
Use insecure orbit URL

### DIFF
--- a/eclipse/updatesite-notp/pom.xml
+++ b/eclipse/updatesite-notp/pom.xml
@@ -84,7 +84,7 @@
 				<repository>
 					<id>eclipse-orbit</id>
 					<layout>p2</layout>
-					<url>https://download.eclipse.org/tools/orbit/downloads/drops/${tools.mdsd.dependencies.orbit-version}/repository</url>
+					<url>http://download.eclipse.org/tools/orbit/downloads/drops/${tools.mdsd.dependencies.orbit-version}/repository</url>
 				</repository>
 				<repository>
 					<id>mdsd.tools-ecoreworkflow</id>


### PR DESCRIPTION
There is a TLS secured orbit URL In the parent POM without target platform. This is problematic because our reliability improving HTTP proxy cannot redirect requests to a highly available mirror anymore. Therefore, we should use the insure URL for the orbit update site.