### PR TITLE
Update javadoc version and enable snapshot repos for nightly build

### DIFF
--- a/eclipse/pom.xml
+++ b/eclipse/pom.xml
@@ -33,7 +33,8 @@
 	</scm>
 
 	<properties>
-		<tycho.version>2.1.0</tycho.version>
+		<tycho.version>2.2.0</tycho.version>
+		<tycho-javadoc.version>2.2.0-SNAPSHOT</tycho-javadoc.version>
 		<org.palladiosimulator.maven.tychotprefresh.version>0.2.6</org.palladiosimulator.maven.tychotprefresh.version>
 		<javadoc.args>
 			-tag "generated:a:Generated class or method."
@@ -112,6 +113,21 @@
 				<org.palladiosimulator.maven.tychotprefresh.filter.0>nightly</org.palladiosimulator.maven.tychotprefresh.filter.0>
 				<updatesite.aggregator.filename>target/classes/nightly.aggr</updatesite.aggregator.filename>
 			</properties>
+
+			<pluginRepositories>
+				<pluginRepository>
+					<id>central</id>
+					<url>https://repo.maven.apache.org/maven2/</url>
+				 </pluginRepository>
+				<pluginRepository>
+				   <id>sonatype-staging</id>
+				   <url>https://oss.sonatype.org/content/groups/staging/</url>
+				</pluginRepository>
+				<pluginRepository>
+					<id>sonatype-snapshots</id>
+					<url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+				 </pluginRepository>
+			 </pluginRepositories>
 		</profile>
 
 		<profile>
@@ -205,7 +221,7 @@
 					<plugin>
 						<groupId>org.palladiosimulator</groupId>
 						<artifactId>tycho-document-bundle-plugin</artifactId>
-						<version>1.1.5</version>
+						<version>${tycho-javadoc.version}</version>
 						<executions>
 							<execution>
 								<id>eclipse-javadoc</id>
@@ -246,7 +262,7 @@
 					<plugin>
 						<groupId>org.palladiosimulator</groupId>
 						<artifactId>tycho-document-bundle-plugin</artifactId>
-						<version>1.1.5</version>
+						<version>${tycho-javadoc.version}</version>
 						<executions>
 							<execution>
 								<id>artifact-javadoc</id>


### PR DESCRIPTION
- Enable plugin resolution via staging and snapshot repositories for nightly build. Resolution via maven central is tried first to speed up things.
- Incremented tycho version to 2.2.0 (currently staging)
- Incremented tycho-javadoc plugin to 2.2.0-SNAPSHOT (until tycho 2.2.0 release is available)

