### PR TITLE
Switch to 2.2.0 release

### DIFF
--- a/eclipse/pom.xml
+++ b/eclipse/pom.xml
@@ -33,8 +33,8 @@
 	</scm>
 
 	<properties>
-		<tycho.version>2.2.0-SNAPSHOT</tycho.version>
-		<tycho-javadoc.version>2.2.0-SNAPSHOT</tycho-javadoc.version>
+		<tycho.version>2.2.0</tycho.version>
+		<tycho-javadoc.version>2.2.0</tycho-javadoc.version>
 		<org.palladiosimulator.maven.tychotprefresh.version>0.2.6</org.palladiosimulator.maven.tychotprefresh.version>
 		<javadoc.args>
 			-tag "generated:a:Generated class or method."


### PR DESCRIPTION
Switch to latest tycho release. Merge once 2.2.0 (https://repo.maven.apache.org/maven2/org/palladiosimulator/tycho-document-bundle-plugin/2.2.0/) of our javadoc plugin is available.