### PR TITLE
Added dagger annotation processing profile

### DIFF
--- a/eclipse/pom.xml
+++ b/eclipse/pom.xml
@@ -739,6 +739,72 @@
 			</build>
 		</profile>
 
+		<profile>
+			<activation>
+				<file>
+					<exists>.enable_dagger_annotation_processing</exists>
+				</file>
+			</activation>
+
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-compiler-plugin</artifactId>
+						<version>3.8.1</version>
+						<executions>
+							<execution>
+								<id>process-dagger-annotations</id>
+								<goals>
+									<goal>compile</goal>
+								</goals>
+								<phase>generate-sources</phase>
+								<configuration>
+									<annotationProcessorPaths>
+										<annotationProcessorPath>
+											<groupId>com.google.dagger</groupId>
+											<artifactId>dagger-compiler</artifactId>
+											<version>2.31</version>
+										</annotationProcessorPath>
+									</annotationProcessorPaths>
+									<proc>only</proc>
+									<generatedSourcesDirectory>${project.basedir}/src-gen/</generatedSourcesDirectory>
+								</configuration>
+							</execution>
+						</executions>
+					</plugin>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-clean-plugin</artifactId>
+						<version>3.1.0</version>
+						<executions>
+							<execution>
+								<id>clean-src-gen</id>
+								<phase>clean</phase>
+								<goals>
+									<goal>clean</goal>
+								</goals>
+								<configuration>
+									<excludeDefaultDirectories>true</excludeDefaultDirectories>
+									<filesets>
+										<fileset>
+											<directory>${project.basedir}</directory>
+											<includes>
+												<include>src-gen/**</include>
+											</includes>
+											<excludes>
+												<exclude>*/.gitkeep</exclude>
+											</excludes>
+										</fileset>
+									</filesets>
+								</configuration>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+
 	</profiles>
 
 </project>


### PR DESCRIPTION
The annotation processing works for SimuLizar. In propose to add it here, to allow for simplified usage also in the extension projects to SimuLizar. As it needs to be activated explicitly, there should be no impact on unrelated projects.