### PR TITLE
PALLADIO-505 Remove old proxy profile.

### DIFF
--- a/eclipse/pom.xml
+++ b/eclipse/pom.xml
@@ -590,52 +590,6 @@
 		</profile>
 
 		<profile>
-			<id>enable-proxy</id>
-			<activation>
-				<property>
-					<name>env.USE_PROXY</name>
-					<value>true</value>
-				</property>
-				<file>
-					<exists>updatesite-aggr</exists>
-				</file>
-			</activation>
-			<build>
-				<plugins>
-					<plugin>
-						<groupId>org.apache.maven.plugins</groupId>
-						<artifactId>maven-antrun-plugin</artifactId>
-						<version>1.8</version>
-						<executions>
-							<!-- see https://wiki.eclipse.org/Tycho/Additional_Tools#tycho-eclipserun-plugin_behind_a_proxy -->
-							<execution>
-								<id>configure-proxies-for-eclipserun</id>
-								<phase>generate-resources</phase>
-								<configuration>
-									<target>
-										<touch file="${project.build.directory}/eclipserun-work/configuration/.settings/org.eclipse.core.net.prefs" mkdirs="true" />
-										<propertyfile file="${project.build.directory}/eclipserun-work/configuration/.settings/org.eclipse.core.net.prefs">
-											<entry key="eclipse.preferences.version" value="1" />
-											<entry key="nonProxiedHosts" value="${http.nonProxyHosts}" />
-											<entry key="org.eclipse.core.net.hasMigrated" value="true" />
-											<entry key="proxyData/HTTP/hasAuth" value="false" />
-											<entry key="proxyData/HTTP/host" value="${http.proxyHost}" />
-											<entry key="proxyData/HTTP/port" value="${http.proxyPort}" />
-											<entry key="systemProxiesEnabled" value="false" />
-										</propertyfile>
-									</target>
-								</configuration>
-								<goals>
-									<goal>run</goal>
-								</goals>
-							</execution>
-						</executions>
-					</plugin>
-				</plugins>
-			</build>
-		</profile>
-
-		<profile>
 			<id>updatesite-maven-aggregator</id>
 			<activation>
 				<file>


### PR DESCRIPTION
The profile is no longer in use after MDSD-Tools/Build-JenkinsLibrary#27 has been merged. However, removal is not urgent, so no release has to be done.